### PR TITLE
🐛 Fix extension import for compatibility with grow v1.0.0

### DIFF
--- a/inline_text_assets/__init__.py
+++ b/inline_text_assets/__init__.py
@@ -1,1 +1,1 @@
-from inline_text_assets import *
+from . inline_text_assets import *


### PR DESCRIPTION
In grow 1 muss im Import ein Punkt vor dem Namen der Extension stehen, sonst funktioniert er nicht.
Ich habe bei fahrrad.hamburg lokal getestet ob das irgendwelche Auswirkungen auf die alten Grow Versionen hat, konnte aber keinen Fehler finden.

@matthiasrohmer kannst du bei Gelegenheit mal schauen, ob das für amp.dev auch in Ordnung ist?